### PR TITLE
Fix: Removed "earlybird" from introduction and added link to registration

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -294,7 +294,7 @@ weight = -100
 		</div>
 		<p><a href="https://youtu.be/Psu_iF_hDQ0">Watch live starting at <time datetime="2023-08-04T18:30-07:00">6:30pm Pacific</time>!</a></p>
 	</div> -->
-	<p>Earlybird registration is open now! Please check out the registration page.</p>
+	<p data-after="2024-06-01 GMT-0700" data-before="2024-08-07 GMT-0700"> Registration is open! Please check out the <a href="/registration">registration page</a>.</p>
 	<!-- <p>Thank you to everyone who attended Irresistible Influence 2023!</p> -->
 	<p>Recordings of last year's conference are available on our <a href="https://www.youtube.com/playlist?list=PLqVg8iJjuJ4cQ4ih5p2siEtzvEIDWK4CO">YouTube channel's 2023 playlist</a>. Please subscribe to the <a href="https://www.youtube.com/channel/UCAinceLJDt98CJWP4hbzn2A">channel</a> and click the bell icon to be notified.</p>
 	<p data-before="2023-08-02 GMT-0700">Check the <a href="/archives">archives</a> for recordings from previous meetings!</p>

--- a/content/registration/_index.html
+++ b/content/registration/_index.html
@@ -19,7 +19,7 @@ weight = 2
 		<p>Other pricing notes:</p>
 		<ul>
 			<li>Registration price adjusts according to age as you register.</li>
-			<li>Registration for children ages 0-6 are free; ages 7-13 are half price.</li>
+			<li>Registration for children ages 0-6 is free; registration for ages 7-13 is half-price.</li>
 			<li>Sabbath registration is free, but required for entry. Sabbath lunch can be purchased during registration.</li>
 		</ul>
 	</div>


### PR DESCRIPTION
Removed "earlybird" from invitation to check out registration page. In the future, should probably add a data range to remove time-constrained wordings. Also added link to registration page and fixed a grammar mistake on the registration page.