### PR TITLE
Feat: added 2025 flyer to handout page and removed errant spaces after data-before tags

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -306,7 +306,7 @@ weight = -100
 		</div>
 		<p><a href="https://youtu.be/yp7V7BLwvAQ">Watch live starting at <time datetime="2024-08-11T09:15-07:00">9:15am Pacific</time>!</a></p>
 	</div>
-	<p data-after="2024-06-01 GMT-0700" data-before="2024-08-07 GMT-0700"> Registration is open! Please check out the <a href="/registration">registration page</a>.</p>
+	<p data-after="2024-06-01 GMT-0700" data-before="2024-08-07 GMT-0700">Registration is open! Please check out the <a href="/registration">registration page</a>.</p>
 	<!-- <p>Thank you to everyone who attended Irresistible Influence 2023!</p> -->
 	<!-- <p>Recordings of last year's conference are available on our <a href="https://www.youtube.com/playlist?list=PLqVg8iJjuJ4cQ4ih5p2siEtzvEIDWK4CO">YouTube channel's 2023 playlist</a>. Please subscribe to the <a href="https://www.youtube.com/channel/UCAinceLJDt98CJWP4hbzn2A">channel</a> and click the bell icon to be notified.</p> -->
 	<p data-before="2023-08-02 GMT-0700">Check the <a href="/archives">archives</a> for recordings from previous meetings!</p>
@@ -465,7 +465,7 @@ weight = -100
 <section id="registration-info">
 	<article>
 		<h1>Pricing and site notes</h1>
-		<p data-before="2025-05-16 GMT-0700"> Earlybird registration is open! Until May 15th registration is $40 per person for the whole event. Afterwards it will be $50 per person. Meals and lodging are priced separately. Children are less, see the registration page.</p>
+		<p data-before="2025-05-16 GMT-0700">Earlybird registration is open! Until May 15th registration is $40 per person for the whole event. Afterwards it will be $50 per person. Meals and lodging are priced separately. Children are less, see the registration page.</p>
 		<p data-after="2025-05-16 GMT-0700" data-before="2025-08-15T20:00-0700">Registration is $50 per person for the whole event. Meals and lodging are priced separately. Children are less, see the registration page.</p>
 		<!-- <p data-after="2025-08-07 GMT-0700" data-before="2025-08-09T20:00-0700">Standard registration is closed. You can still register for Sabbath.</p> -->
 		<p data-after="2025-08-15T20:00-0700">Registration is closed.</p>

--- a/content/handouts.html
+++ b/content/handouts.html
@@ -14,7 +14,7 @@ weight = 10
 <section>
 	<h1>Printable documents</h1>
 	<ul>
-		<!-- <li><a href="">2024 bulletin insert</a> - designed to print in full color on 8.5x11 inch paper.</li> -->
+		<li><a href="/static/download/2025/Unshaken.pdf">2025 bulletin insert</a> - designed to print in full color on 8.5x11 inch paper.</li>
 		<!-- <li><a href="/download/2024/GYCWEST_2024-11x17.png">2024 poster</a> - designed to print in full color on 11x17 inch paper.</li> -->
 	</ul>
 </section>

--- a/static/download/2025/Unshaken.pdf
+++ b/static/download/2025/Unshaken.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baff2b3f2835bef31a486d3241daa7a0a0a26ffec0976a00e65efb02a04f511d
+size 13456003


### PR DESCRIPTION
I noticed a space following the data-before and after tags on the instances that are not rendering correctly on iOS. Unsure if this is the issue, but I removed them in an attempt to address it.