### PR TITLE
Fix: broken flyer link

### DIFF
--- a/content/handouts.html
+++ b/content/handouts.html
@@ -14,7 +14,7 @@ weight = 10
 <section>
 	<h1>Printable documents</h1>
 	<ul>
-		<li><a href="/static/download/2025/Unshaken.pdf">2025 bulletin insert</a> - designed to print in full color on 8.5x11 inch paper.</li>
+		<li><a href="/download/2025/Unshaken.pdf">2025 bulletin insert</a> - designed to print in full color on 8.5x11 inch paper.</li>
 		<!-- <li><a href="/download/2024/GYCWEST_2024-11x17.png">2024 poster</a> - designed to print in full color on 11x17 inch paper.</li> -->
 	</ul>
 </section>


### PR DESCRIPTION
The link to the flyer did not require the /static portion of the file path and was thus broken.